### PR TITLE
Add support for Python 3.9-3.10 and Django 3.2-4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     needs: checks
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         django-version: [2.2.8, 3.0, 3.1]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,11 @@ jobs:
     needs: checks
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
-        django-version: [2.2.8, 3.0, 3.1]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        django-version: ["2.2.8", "3.0", "3.1", "3.2", "4.0"]
+        exclude:
+          - python-version: "3.7"
+            django-version: "4.0"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Django 3.2-4.0 support
+- Python 3.9-3.10 support
+
 ### Changed
 - Switched CI from Travis to Github Actions
 - Renamed default from `master` -> `main`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Switched CI from Travis to Github Actions
 - Renamed default from `master` -> `main`
 
+### Removed
+- Python 3.6 support
+
 ## [0.4.0] - 2021-02-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6.1"
+python = "^3.7"
 Django = ">= 2.2"
 
 [tool.poetry.dev-dependencies]
@@ -33,7 +33,7 @@ profile = "black"
 
 [tool.black]
 line-length = 88
-target_version = ["py36", "py37", "py38"]
+target_version = ["py37", "py38"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ classifiers = [
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
+    "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Testing",

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import path
 from django.views.generic.base import RedirectView
 
 from tests.views import foo, foo_api
 
 urlpatterns = [
-    url(r"^api/foo/$", foo_api),
-    url(r"^foo/$", foo),
-    url(r"^bar/$", RedirectView.as_view(url="/foo/", permanent=False)),
+    path("api/foo/", foo_api),
+    path("foo/", foo),
+    path("bar/", RedirectView.as_view(url="/foo/", permanent=False)),
 ]


### PR DESCRIPTION
- Drops support for Python 3.6
- Otherwise, just updates the build matrix to mark support for Python 3.9-3.10 and Django 3.2-4.0